### PR TITLE
Removing keycloak requirement

### DIFF
--- a/roles/sigstore_scaffolding/defaults/main.yml
+++ b/roles/sigstore_scaffolding/defaults/main.yml
@@ -97,6 +97,8 @@ ct_logprefix: sigstoreansible
 
 scaffolding_utils_image: quay.io/ablock/sigstore-scaffolding-helper:latest
 
+keycloak_enabled: true
+keycloak_url: keycloak.{{ base_hostname }}
 keycloak_wait_increment_seconds: 60
 keycloak_postgresql_user: "keycloak"
 keycloak_postgresql_password: "keycloak"

--- a/roles/sigstore_scaffolding/defaults/main.yml
+++ b/roles/sigstore_scaffolding/defaults/main.yml
@@ -28,6 +28,10 @@ sigstore_trillian_templates:
   - manifests/trillian/trillian-logserver.yaml
   - manifests/trillian/trillian-logsigner.yaml
 
+ctlog_enabled: true
+tuf_enabled: true
+
+trillian_enabled: true
 trillian:
   mysql:
    user: mysql
@@ -74,7 +78,7 @@ remote_ctlog_public_key: "{{ certs_dir }}/{{ ctlog_public_key_filename }}"
 remote_rekor_signer: "{{ certs_dir }}/{{ rekor_signer_filename }}"
 remote_rekor_public_key: "{{ certs_dir }}/{{ rekor_public_key_filename }}"
 
-
+rekor_enabled: true
 rekor_public_key_retries: 5
 rekor_public_key_delay: 10
 fulcio_server_config: "{{ kube_configmap_dir }}/fulcio-config.yaml"
@@ -90,6 +94,7 @@ keycloak_certs_config: "{{ kube_configmap_dir }}/keycloak-certs.yaml"
 setup_host_dns: true
 base_hostname: ""
 
+fulcio_enabled: true
 fulcio_ca_passphrase: sigstore
 ctlog_ca_passphrase: sigstore
 rekor_ca_passphrase: sigstore

--- a/roles/sigstore_scaffolding/tasks/keycloak/setup.yml
+++ b/roles/sigstore_scaffolding/tasks/keycloak/setup.yml
@@ -8,11 +8,11 @@
 
 - name: Set Keycloak Hostname
   ansible.builtin.set_fact:
-    keycloak_auth_url: https://{{ keycloak_url }}{{ keycloak_auth_endpoint }}
+    keycloak_auth_url: "https://{{ keycloak_url }}{{ keycloak_auth_endpoint }}"
 
 - name: "Wait until Keycloak becomes active and ready"
   ansible.builtin.uri:
-    url: https://{{ keycloak_url }}/health/ready
+    url: "https://{{ keycloak_url }}/health/ready"
     method: GET
     validate_certs: false
   register: keycloak_status

--- a/roles/sigstore_scaffolding/tasks/keycloak/setup.yml
+++ b/roles/sigstore_scaffolding/tasks/keycloak/setup.yml
@@ -8,15 +8,11 @@
 
 - name: Set Keycloak Hostname
   ansible.builtin.set_fact:
-    keycloak_hostname: "https://keycloak.{{ base_hostname }}"
-
-- name: Set Keycloak Hostname
-  ansible.builtin.set_fact:
-    keycloak_auth_url: "{{ keycloak_hostname }}{{ keycloak_auth_endpoint }}"
+    keycloak_auth_url: https://{{ keycloak_url }}{{ keycloak_auth_endpoint }}
 
 - name: "Wait until Keycloak becomes active and ready"
   ansible.builtin.uri:
-    url: "{{ keycloak_hostname }}/health/ready"
+    url: https://{{ keycloak_url }}/health/ready
     method: GET
     validate_certs: false
   register: keycloak_status

--- a/roles/sigstore_scaffolding/tasks/podman.yml
+++ b/roles/sigstore_scaffolding/tasks/podman.yml
@@ -24,18 +24,24 @@
 
 - name: Configure/Deploy Trillian
   ansible.builtin.include_tasks: podman/trillian.yml
+  when: trillian_enabled | bool
 
 - name: Setup Trillian Tree ID
   ansible.builtin.include_tasks: podman/createtree.yml
+  when: trillian_enabled | bool
 
 - name: Configure/Deploy Rekor
   ansible.builtin.include_tasks: podman/rekor.yml
+  when: rekor_enabled | bool
 
 - name: Configure/Deploy Fulcio
   ansible.builtin.include_tasks: podman/fulcio.yml
+  when: fulcio_enabled | bool
 
 - name: Configure/Deploy ctlog
   ansible.builtin.include_tasks: podman/ctlog.yml
+  when: ctlog_enabled | bool
 
 - name: Configure/Deploy tuf
   ansible.builtin.include_tasks: podman/tuf.yml
+  when: tuf_enabled | bool

--- a/roles/sigstore_scaffolding/tasks/podman.yml
+++ b/roles/sigstore_scaffolding/tasks/podman.yml
@@ -20,6 +20,7 @@
 
 - name: Configure/Deploy keycloak
   ansible.builtin.include_tasks: podman/keycloak.yml
+  when: keycloak_enabled | bool
 
 - name: Configure/Deploy Trillian
   ansible.builtin.include_tasks: podman/trillian.yml

--- a/roles/sigstore_scaffolding/templates/configs/fulcio-oidc.conf.j2
+++ b/roles/sigstore_scaffolding/templates/configs/fulcio-oidc.conf.j2
@@ -1,8 +1,8 @@
 {
     "OIDCIssuers": {
-    "https://keycloak.{{ base_hostname }}{{ keycloak_auth_endpoint }}/realms/{{ keycloak_realm }}": {
+    "https://{{ keycloack_url }}{{ keycloak_auth_endpoint }}/realms/{{ keycloak_realm }}": {
         "ClientID": "{{ keycloak_sigstore_client }}",
-        "IssuerURL": "https://keycloak.{{ base_hostname }}{{ keycloak_auth_endpoint }}/realms/{{ keycloak_realm }}",
+        "IssuerURL": "https://{{ keycloak_url }}{{ keycloak_auth_endpoint }}/realms/{{ keycloak_realm }}",
         "Type": "email"
         }
     }

--- a/roles/sigstore_scaffolding/templates/configs/fulcio-oidc.conf.j2
+++ b/roles/sigstore_scaffolding/templates/configs/fulcio-oidc.conf.j2
@@ -1,6 +1,6 @@
 {
     "OIDCIssuers": {
-    "https://{{ keycloack_url }}{{ keycloak_auth_endpoint }}/realms/{{ keycloak_realm }}": {
+    "https://{{ keycloak_url }}{{ keycloak_auth_endpoint }}/realms/{{ keycloak_realm }}": {
         "ClientID": "{{ keycloak_sigstore_client }}",
         "IssuerURL": "https://{{ keycloak_url }}{{ keycloak_auth_endpoint }}/realms/{{ keycloak_realm }}",
         "Type": "email"

--- a/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
+++ b/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
@@ -45,21 +45,27 @@ stream {
     rekor.{{ base_hostname }}  rekor-server-pod:3000;
     tuf.{{ base_hostname }}  tuf-pod:8080;
     fulcio.{{ base_hostname }}  fulcio-server-pod:5555;
-    keycloak.{{ base_hostname }}  keycloak:8080;
+{% if keycloak_enabled %}
+    {{ keycloak_url }}  keycloak:8080;
+{% endif %}
   }
 
   map $ssl_server_name $targetCert {
     rekor.{{ base_hostname }} /certs/ingress-rekor.pem;
     tuf.{{ base_hostname }} /certs/ingress-tuf.pem;
     fulcio.{{ base_hostname }} /certs/ingress-fulcio.pem;
-    keycloak.{{ base_hostname }} /certs/ingress-keycloak.pem;
+{% if keycloak_enabled %}
+    {{ keycloak_url }}  /certs/ingress-keycloak.key;
+{% endif %}
   }
 
   map $ssl_server_name $targetCertKey {
     rekor.{{ base_hostname }}  /certs/ingress-rekor.key;
     tuf.{{ base_hostname }}  /certs/ingress-tuf.key;
     fulcio.{{ base_hostname }}  /certs/ingress-fulcio.key;
-    keycloak.{{ base_hostname }}  /certs/ingress-keycloak.key;
+{% if keycloak_enabled %}
+    {{ keycloak_url }}  /certs/ingress-keycloak.key;
+{% endif %}
   }
   
   server {

--- a/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
+++ b/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
@@ -10,8 +10,10 @@ events {
     worker_connections  1024;
 }
 
-
 http {
+    map_hash_bucket_size 128;
+    map_hash_max_size 128;
+    server_names_hash_bucket_size  128;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
@@ -41,28 +43,47 @@ http {
 
 stream {  
 
+  map_hash_bucket_size 128;
   map $ssl_server_name $targetBackend {
+{% if rekor_enabled %}
     rekor.{{ base_hostname }}  rekor-server-pod:3000;
+{% endif %}
+{% if tuf_enabled %}
     tuf.{{ base_hostname }}  tuf-pod:8080;
+{% endif %}
+{% if fulcio_enabled %}
     fulcio.{{ base_hostname }}  fulcio-server-pod:5555;
+{% endif %}
 {% if keycloak_enabled %}
     {{ keycloak_url }}  keycloak:8080;
 {% endif %}
   }
 
   map $ssl_server_name $targetCert {
+{% if rekor_enabled %}
     rekor.{{ base_hostname }} /certs/ingress-rekor.pem;
+{% endif %}
+{% if tuf_enabled %}
     tuf.{{ base_hostname }} /certs/ingress-tuf.pem;
+{% endif %}
+{% if fulcio_enabled %}
     fulcio.{{ base_hostname }} /certs/ingress-fulcio.pem;
+{% endif %}
 {% if keycloak_enabled %}
     {{ keycloak_url }}  /certs/ingress-keycloak.pem;
 {% endif %}
   }
 
   map $ssl_server_name $targetCertKey {
+{% if rekor_enabled %}
     rekor.{{ base_hostname }}  /certs/ingress-rekor.key;
+{% endif %}
+{% if tuf_enabled %}
     tuf.{{ base_hostname }}  /certs/ingress-tuf.key;
+{% endif %}
+{% if fulcio_enabled %}
     fulcio.{{ base_hostname }}  /certs/ingress-fulcio.key;
+{% endif %}
 {% if keycloak_enabled %}
     {{ keycloak_url }}  /certs/ingress-keycloak.key;
 {% endif %}

--- a/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
+++ b/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
@@ -55,7 +55,7 @@ stream {
     tuf.{{ base_hostname }} /certs/ingress-tuf.pem;
     fulcio.{{ base_hostname }} /certs/ingress-fulcio.pem;
 {% if keycloak_enabled %}
-    {{ keycloak_url }}  /certs/ingress-keycloak.key;
+    {{ keycloak_url }}  /certs/ingress-keycloak.pem;
 {% endif %}
   }
 

--- a/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
+++ b/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
@@ -45,21 +45,27 @@ stream {
     rekor.{{ base_hostname }}  rekor-server-pod:3000;
     tuf.{{ base_hostname }}  tuf-pod:8080;
     fulcio.{{ base_hostname }}  fulcio-server-pod:5555;
-    keycloak.{{ base_hostname }}  keycloak:8080;
+{% if keycloak_enabled %}
+    {{ keycloak_url }}  keycloak:8080;
+{% endif %}
   }
 
   map $ssl_server_name $targetCert {
     rekor.{{ base_hostname }} /certs/ingress-rekor.pem;
     tuf.{{ base_hostname }} /certs/ingress-tuf.pem;
     fulcio.{{ base_hostname }} /certs/ingress-fulcio.pem;
-    keycloak.{{ base_hostname }} /certs/ingress-keycloak.pem;
+{% if keycloak_enabled %}
+    {{ keycloak_url }}  keycloak:8080;
+{% endif %}
   }
 
   map $ssl_server_name $targetCertKey {
     rekor.{{ base_hostname }}  /certs/ingress-rekor.key;
     tuf.{{ base_hostname }}  /certs/ingress-tuf.key;
     fulcio.{{ base_hostname }}  /certs/ingress-fulcio.key;
-    keycloak.{{ base_hostname }}  /certs/ingress-keycloak.key;
+{% if keycloak_enabled %}
+    {{ keycloak_url }}  keycloak:8080;
+{% endif %}
   }
   
   server {

--- a/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
+++ b/roles/sigstore_scaffolding/templates/configs/nginx.conf.j2
@@ -45,27 +45,21 @@ stream {
     rekor.{{ base_hostname }}  rekor-server-pod:3000;
     tuf.{{ base_hostname }}  tuf-pod:8080;
     fulcio.{{ base_hostname }}  fulcio-server-pod:5555;
-{% if keycloak_enabled %}
-    {{ keycloak_url }}  keycloak:8080;
-{% endif %}
+    keycloak.{{ base_hostname }}  keycloak:8080;
   }
 
   map $ssl_server_name $targetCert {
     rekor.{{ base_hostname }} /certs/ingress-rekor.pem;
     tuf.{{ base_hostname }} /certs/ingress-tuf.pem;
     fulcio.{{ base_hostname }} /certs/ingress-fulcio.pem;
-{% if keycloak_enabled %}
-    {{ keycloak_url }}  keycloak:8080;
-{% endif %}
+    keycloak.{{ base_hostname }} /certs/ingress-keycloak.pem;
   }
 
   map $ssl_server_name $targetCertKey {
     rekor.{{ base_hostname }}  /certs/ingress-rekor.key;
     tuf.{{ base_hostname }}  /certs/ingress-tuf.key;
     fulcio.{{ base_hostname }}  /certs/ingress-fulcio.key;
-{% if keycloak_enabled %}
-    {{ keycloak_url }}  keycloak:8080;
-{% endif %}
+    keycloak.{{ base_hostname }}  /certs/ingress-keycloak.key;
   }
   
   server {

--- a/roles/sigstore_scaffolding/templates/manifests/keycloak/keycloak.yaml
+++ b/roles/sigstore_scaffolding/templates/manifests/keycloak/keycloak.yaml
@@ -46,9 +46,9 @@ spec:
         - name: KC_HEALTH_ENABLED
           value: "true"
         - name: KC_HOSTNAME_URL
-          value: "https://keycloak.{{ base_hostname }}"
+          value: "https://{{ keycloak_url }}"
         - name: KC_HOSTNAME_ADMIN_URL
-          value: "https://keycloak.{{ base_hostname }}"
+          value: "https://{{ keycloak_url }}"
       args:
         - start
       image: quay.io/keycloak/keycloak@sha256:b8f2a453a17a244a829fdafdb08dd77f719d3622bc3987c76a81771c0913b882


### PR DESCRIPTION
If an organization already has keycloak deployed we should not install a keycloak. We should allow for the work to integrate with an existing instance