### PR TITLE
Don't use sudo on delegate task

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,4 +4,3 @@
 forks = 50
 host_key_checking = False
 remote_user = ec2-user
-private_key_file = aws_keys_pairs.pem

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "aws_instance" "sigstore" {
 resource "null_resource" "configure-sigstore" {
   depends_on = [aws_instance.sigstore]
   provisioner "local-exec" {
-    command = "ansible-playbook -i inventory playbooks/install.yml -e registry_username='${var.rh_username}' -e registry_password='${var.rh_password}' -e base_hostname=${var.base_domain}"
+    command = "ansible-playbook --private-key=./aws_keys_pairs.pem -i inventory playbooks/install.yml -e registry_username='${var.rh_username}' -e registry_password='${var.rh_password}' -e base_hostname=${var.base_domain}"
   }
 }
 

--- a/roles/sigstore_scaffolding/tasks/keycloak/create_user.yml
+++ b/roles/sigstore_scaffolding/tasks/keycloak/create_user.yml
@@ -13,6 +13,7 @@
       - 200
   register: keycloak_user_result
   delegate_to: localhost
+  become: false
 
 - name: Create User {{ keycloak_user.username }}
   ansible.builtin.uri:
@@ -35,6 +36,7 @@
     status_code:
       - 201
   delegate_to: localhost
+  become: false
   when: keycloak_user_result.json | selectattr('username', 'equalto', keycloak_user.username) | list | length == 0
 
 - name: Query Update List of Users for {{ keycloak_user.username }}
@@ -49,6 +51,7 @@
     status_code:
       - 200
   register: keycloak_user_result
+  become: false
   delegate_to: localhost
 
 - name: Set User Password for {{ keycloak_user.username }}
@@ -68,3 +71,4 @@
     status_code:
       - 204
   delegate_to: localhost
+  become: false

--- a/roles/sigstore_scaffolding/tasks/keycloak/generate_token.yml
+++ b/roles/sigstore_scaffolding/tasks/keycloak/generate_token.yml
@@ -22,6 +22,7 @@
   #no_log: true
   register: keycloak_token_result
   delegate_to: localhost
+  become: false
 
 - name: Set SSO Token
   ansible.builtin.set_fact:

--- a/roles/sigstore_scaffolding/tasks/keycloak/setup.yml
+++ b/roles/sigstore_scaffolding/tasks/keycloak/setup.yml
@@ -20,6 +20,7 @@
   retries: 25
   delay: 10
   delegate_to: localhost
+  become: false
 
 - name: Create sigstore realm
   community.general.keycloak_realm:
@@ -35,6 +36,7 @@
     validate_certs: no
     wait_increment_seconds: "{{ keycloak_wait_increment_seconds }}"
   delegate_to: localhost
+  become: false
 
 - name: Create sigstore client 
   community.general.keycloak_client:
@@ -53,6 +55,7 @@
     state: present
     validate_certs: no
   delegate_to: localhost
+  become: false
 
 - name: Create Users
   block:

--- a/roles/sigstore_scaffolding/tasks/podman/tuf.yml
+++ b/roles/sigstore_scaffolding/tasks/podman/tuf.yml
@@ -27,6 +27,7 @@
   delay: "{{ rekor_public_key_delay }}"
   register: rekor_public_key_result
   delegate_to: localhost
+  become: false
 
 
 - name: Create tuf ConfigMap


### PR DESCRIPTION
Using sudo on delegate tasks causes priv escalation on the system running ansible or on ansible auto hub. We should not need sudo for these steps